### PR TITLE
Build python in setup

### DIFF
--- a/parametric_plasma_source/build_python.py
+++ b/parametric_plasma_source/build_python.py
@@ -7,9 +7,6 @@ make_file = "Makefile"
 
 py_file = "source.py"
 
-if os.path.exists(py_file):
-    os.remove(py_file)
-
 def write_disclaimer(py_file_path):
     disclaimer = "\"\"\"\n"
     disclaimer += "Auto-generated file. To edit, run `python build_python.py`.\n"
@@ -29,8 +26,31 @@ def generate_variable(cpp_file_path, variable_name, py_file_path, end_str="\n\n"
         with open(py_file_path, "a+") as f_py:
             f_py.write(py_lines)
 
-write_disclaimer(py_file)
-generate_variable(source_sampling_cpp, "source_sampling_cpp", py_file)
-generate_variable(plasma_source_cpp, "plasma_source_cpp", py_file)
-generate_variable(plasma_source_hpp, "plasma_source_hpp", py_file)
-generate_variable(make_file, "make_file", py_file, "\n")
+def build(source_dir="."):
+    output_path = os.path.join(source_dir, py_file)
+
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    write_disclaimer(output_path)
+    generate_variable(
+        os.path.join(source_dir, source_sampling_cpp),
+        "source_sampling_cpp",
+        output_path
+    )
+    generate_variable(
+        os.path.join(source_dir, plasma_source_cpp),
+        "plasma_source_cpp",
+        output_path
+    )
+    generate_variable(
+        os.path.join(source_dir, plasma_source_hpp),
+        "plasma_source_hpp",
+        output_path
+    )
+    generate_variable(
+        os.path.join(source_dir, make_file),
+        "make_file",
+        output_path,
+        "\n"
+    )

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import sys
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
 
+from parametric_plasma_source.build_python import build as build_python
 
 class CMakeExtention(Extension):
     def __init__(self, name, sourcedir=""):
@@ -62,6 +63,8 @@ class CMakeBuild(build_ext):
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+build_python(source_dir="parametric_plasma_source")
 
 setup(
     name="parametric_plasma_source",


### PR DESCRIPTION
Slight tweak to the setup.py steps to ensure that the latest C++ template files are always used when installing the Python version. This saves the user from needing to remember that the C++ templates should be recreated whenever the C++ is changed.